### PR TITLE
Add the port designation lv2:control

### DIFF
--- a/lv2ttl/property_example.ttl.in
+++ b/lv2ttl/property_example.ttl.in
@@ -54,6 +54,7 @@ propex:mono
 		lv2:index 0;
 		lv2:symbol "control";
 		lv2:name "Control Input";
+		lv2:designation lv2:control ;
 	] , [
 		a lv2:AudioPort ,
 			lv2:InputPort ;


### PR DESCRIPTION
The example needs `lv2:designation` set, so Jalv is able to match a port index to parameters.
Otherwise this error will be seen: `UI write to out of range port index -1`