### PR TITLE
Fix build with old gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ ifeq ($(shell pkg-config --exists lv2 || echo no), no)
   $(error "LV2 SDK was not found")
 endif
 
-override CFLAGS += `pkg-config --cflags lv2`
+override CFLAGS += `pkg-config --cflags lv2` -std=c99
 
 # build target definitions
 default: all


### PR DESCRIPTION
Otherwise build fails with:
```
In file included from /Shared/mpb-workdir/modduox/host/usr/aarch64-buildroot-linux-gnu/sysroot/usr/lib/lv2/atom.lv2/forge.h:54:0,
                 from src/property_example.c:27:
/Shared/mpb-workdir/modduox/host/usr/aarch64-buildroot-linux-gnu/sysroot/usr/lib/lv2/atom.lv2/util.h: In function 'lv2_atom_object_query':
/Shared/mpb-workdir/modduox/host/usr/aarch64-buildroot-linux-gnu/sysroot/usr/lib/lv2/atom.lv2/util.h:336:2: error: 'for' loop initial declarations are only allowed in C99 or C11 mode
  for (LV2_Atom_Object_Query* q = query; q->key; ++q) {
```